### PR TITLE
feat: add v5.0.0 release notes and upgrade documentation

### DIFF
--- a/docs/en/lifecycle_policy.mdx
+++ b/docs/en/lifecycle_policy.mdx
@@ -12,18 +12,28 @@ title: Lifecycle Policy
 
 Below is the lifecycle schedule for released versions of the Alauda Cache Service for Redis OSS:
 
-| Version | Release Date | End of Support |
-|:--------|:-------------|:---------------|
-| v4.1.x  | 2025-08-22   | 2027-08-30     |
+| Version | Release Date | End of Full Support | End of Maintenance |
+|:--------|:-------------|:--------------------|:-------------------|
+| v5.0.x  | 2026-04-28   | 2027-04-30          | 2028-04-30         |
+| v4.1.x  | 2025-08-22   | 2026-08-30          | 2027-08-30         |
 
 ## Release Policy
 
-* A new patch version of Alauda Cache Service for Redis OSS is released as needed to address bugs and security vulnerabilities.
-* Minor version releases are driven by significant updates to the underlying Redis server, the implementation of new features, or emerging security requirements.
+* A new patch version of Alauda Cache Service for Redis OSS is released as needed to address bugs and security vulnerabilities. Patch releases do not introduce new features.
+* Minor and major version releases are driven by significant updates to the underlying Redis server, the implementation of new features, or emerging security requirements.
+
+## Support Phases
+
+Each minor version progresses through two support phases over its lifecycle:
+
+* **Full Support (Year 1)**: From the release date until the end of full support. The version receives all bug fixes and security patches via patch releases on the same minor line.
+* **Maintenance (Year 2)**: From the end of full support until the end of maintenance. The version receives only critical bug fixes and security patches; non-critical fixes are not backported.
+
+After the end of maintenance, the version is no longer supported. Customers should plan to upgrade to a supported version before this date.
 
 ## Maintenance Policy
 
-During a version's maintenance period, Alauda provides the following services:
+During a version's supported lifecycle, Alauda provides the following services:
 
 * **Upstream Patching**: We actively track official Redis patch releases and promptly deliver critical bug fixes and security vulnerability patches.
 * **Security Updates**: We release security updates for the service operator on-demand to address vulnerabilities and ensure stability.

--- a/docs/en/release_notes.mdx
+++ b/docs/en/release_notes.mdx
@@ -6,14 +6,37 @@ i18n:
 title: Release Notes
 ---
 
+# Release Notes
+
 ## Compatibility and support matrix
 
 The following table shows the compatibility and support matrix between the Alauda Cache Service for Redis OSS and ACP versions.
 
-| Alauda Cache Service for Redis OSS Version | Redis Versions         | ACP Version |
-|:-------------------------------------------|------------------------|:------------|
-| v4.1.0                                     | 5.0.14, 6.0.20, 7.2.10 | v4.1        |
-| v4.0.x                                     | 5.0.14, 6.0.20, 7.2.x  | v4.0        |
+| Alauda Cache Service for Redis OSS Version | Redis Versions         | ACP Version      |
+|:-------------------------------------------|------------------------|:-----------------|
+| v5.0.0                                     | 6.0.21, 7.2.12, 8.4.2  | v4.1, v4.2, v4.3 |
+| v4.1.0                                     | 5.0.14, 6.0.20, 7.2.10 | v4.1             |
+| v4.0.x                                     | 5.0.14, 6.0.20, 7.2.x  | v4.0             |
+
+## v5.0.0
+
+### New and Optimized Features
+
+#### Redis 8.4 Support
+
+Added support for Redis 8.4 (8.4.2), enabling users to provision and manage instances on the latest Redis Server release alongside the existing 6.0 and 7.2 series.
+
+#### Expanded APIs for Redis Modules
+
+The Alauda Cache Service for Redis OSS APIs have been expanded to support Redis modules, allowing users to configure and manage modules on Redis instances.
+
+### Fixed Issues
+
+{/* release-notes-for-bugs?template=mw-redis-v5.0-fixed&project=Middleware */}
+
+### Known Issues
+
+{/* release-notes-for-bugs?template=mw-redis-v5.0-known&project=Middleware */}
 
 ## v4.1.0
 
@@ -68,4 +91,3 @@ When using LoadBalancer, ensure that the cluster has available external address 
 ### Known Issues
 
 {/* release-notes-for-bugs?template=mw-redis-v4.0-known&project=Middleware */}
-

--- a/docs/en/upgrade.mdx
+++ b/docs/en/upgrade.mdx
@@ -8,62 +8,87 @@ title: Upgrade
 
 # Upgrade
 
-This document provides technical guidance for upgrading Alauda Cache Service for Redis OSS, including version compatibility, upgrade paths, and operational procedures.
+The Alauda Cache Service for Redis OSS is engineered to provide service continuity and data security across all supported versions. This guide details version compatibility and outlines the recommended upgrade paths to facilitate a seamless transition for your environment.
+
+<Directive type="tip" title="Upgrade Tips">
+Prior to upgrading a production environment, it is highly recommended to validate the upgrade process within a development or staging environment. This preliminary step helps identify and mitigate potential compatibility issues, including hardware-related conflicts, before they can affect production services.
+</Directive>
 
 ## Version Compatibility Principles
 
-Alauda Cache Service for Redis OSS follows semantic versioning with the following compatibility guarantees:
+The Alauda Cache Service for Redis OSS adheres to semantic versioning principles, providing the following compatibility guarantees:
 
-* **Patch versions** (x.y.**z**) within the same minor version are fully backward and forward compatible
-* **Minor versions** (x.**y**.z) within the same major version maintain API and feature compatibility
-* **Major versions** (**x**.y.z) may introduce breaking changes and require specific upgrade procedures
+*   **Patch versions** (x.y.**z**) are fully backward and forward compatible within the same minor version series.
+*   **Minor versions** (x.**y**.z) maintain API and feature compatibility within the same major version.
+*   **Major versions** (**x**.y.z) may introduce breaking changes that require specific upgrade procedures.
 
 ## Prerequisites
 
-Before initiating any upgrade operation, verify the following conditions:
+Before initiating an upgrade, ensure that the following prerequisites are met:
 
-1. **Version Compatibility**: Current version must be within supported upgrade paths
-2. **Component Health**: All Redis instances must report Ready status
-3. **Resource Availability**: Cluster must have sufficient CPU, memory, and storage resources
-4. **Backup**: Ensure recent backups of critical data and configuration
+1.  **Version Compatibility**: The current version must be on a supported upgrade path.
+2.  **Component Health**: All Redis instances must report a `Ready` status.
+3.  **Resource Availability**: The cluster must possess adequate CPU, memory, and storage resources to accommodate the upgrade.
+4.  **Backup**: Recent backups of all critical data and configurations must be available.
 
 ## Supported Upgrade Paths
 
-The following upgrade matrix details tested version combinations and their dependencies:
+The following matrix outlines the tested version combinations and their respective dependencies:
 
-| Alauda Cache Service for Redis OSS Version | Redis Server Versions      | ACP Version | Kubernetes Versions       |
-|:-------------------------------------------|:---------------------------|:------------|:--------------------------|
-| v4.1.0                                     | 5.0.14, 6.0.20, 7.2.10     | v4.1.0      | 1.29, 1.30, 1.31, 1.32    |
-| v4.0.x                                     | 5.0.14, 6.0.20, 7.2.x      | v4.0.x      | 1.28, 1.29, 1.30, 1.31    |
+| Alauda Cache Service for Redis OSS Version | Redis Server Versions      | ACP Version      |
+|:-------------------------------------------|:---------------------------|:-----------------|
+| v5.0.0                                     | 6.0.21, 7.2.12, 8.4.2      | v4.1, v4.2, v4.3 |
+| v4.1.0                                     | 5.0.14, 6.0.20, 7.2.10     | v4.1             |
+| v4.0.x                                     | 5.0.14, 6.0.20, 7.2.x      | v4.0             |
+
+<Directive type="note" title="ACP v4.3 Compatibility">
+Alauda Cache Service for Redis OSS v4.1.x and v4.0.x have not been tested on ACP v4.3. Before upgrading to ACP v4.3, please upgrade Alauda Cache Service for Redis OSS to v5.0.0 first.
+</Directive>
 
 ## Upgrade Strategies
 
 ### Minor Version Upgrade
 
-* **Approach**: Any minor version can be upgraded to a newer minor version (e.g., 4.0.x → 4.2.x).
-* **Benefits**: Minimizes risk and ensures smooth transition between versions
+*   **Approach**: Direct upgrades are supported from any minor version to a newer release within the same major version (e.g., `4.0.x` → `4.1.0`).
+*   **Benefits**: This approach minimizes operational risk and facilitates a seamless transition between versions.
 
 ### Patch Version Upgrade
 
-* **Compatibility**: Fully compatible within the same minor version series
-* **Example**: Upgrade from `4.1.0` to `4.1.1` for bug fixes and security patches
+*   **Compatibility**: Patch versions are fully compatible within the same minor version series.
+*   **Example**: Upgrading within the same minor series (e.g., `x.y.0` → `x.y.1`) applies the latest bug fixes and security patches.
 
 ### Major Version Upgrade
 
-* **Requirement**: Must upgrade to the earliest available minor release of the target major version first
-* **Procedure**: Follow specific major version upgrade documentation for detailed steps
-* **Considerations**: May require configuration changes and feature compatibility review
+*   **Requirement**: When upgrading across major versions (e.g., `4.1.0` → `5.0.0`), upgrade directly to the latest available release of the target major version.
+*   **Procedure**: Follow the [Upgrade Steps](#upgrade-steps) below to upgrade the operator, then upgrade individual instances per the [Instance Upgrade Guide](./how_to/30-upgrade.mdx).
+*   **Considerations**: Major upgrades may necessitate configuration modifications and a comprehensive review of feature compatibility.
 
-## Upgrade Execution
+## Upgrade Steps
 
-Alauda Cache Service for Redis OSS supports two upgrade execution modes:
+1.  Download the target version of the `Alauda Cache Service for Redis OSS` plugin from AlaudaCloud to a node that has access to your ACP cluster.
+2.  Utilize the `violet` package management tool to upload the plugin to the target cluster. For detailed instructions, refer to the <ExternalSiteLink name="acp" href="extend/upload_package.html" children="Upload Packages" /> documentation.
+3.  Upgrades follow the strategy configured in the Subscription:
+    *   `Automatic Upgrade`: The plugin upgrades automatically upon upload.
+    *   `Manual Upgrade`:
+         <Tabs>
+           <Tab label="CLI">
+           ```bash
+           # Check for available upgrades
+           $ kubectl -n redis-system get subscriptions.operators.coreos.com redis-operator -o go-template='{{ printf "Installed: %s\n  Current: %s" .status.installedCSV .status.currentCSV }}'
 
-* **Automatic**: System automatically detects and applies new versions when available
-* **Manual**: Requires explicit administrator approval before initiating upgrade procedures
+           # If an upgrade is available, find the corresponding InstallPlan for the Subscription
+           $ kubectl -n redis-system get subscriptions.operators.coreos.com redis-operator -o jsonpath='{.status.installplan.name}'
 
-### Operational Considerations
-
-* **Downtime**: Plan for minimal service interruption during upgrade operations
-* **Rollback**: Ensure rollback procedures are understood and tested
-* **Monitoring**: Closely monitor system metrics and logs during upgrade process
-* **Validation**: Perform post-upgrade validation of all critical functionality
+           # Approve the InstallPlan to proceed with the upgrade
+           $ kubectl -n redis-system patch --type='json' -p='[{"op":"replace","path":"/spec/approved","value":true}]'
+           ```
+           </Tab>
+           <Tab label="Web Console">
+           - Log in to the web console and switch to the Administrator view.
+           - Navigate to **Marketplace** > **OperatorHub** > **Alauda Cache Service for Redis OSS detail page**.
+           - Click the **Confirm** link in the **New Version Detected** notification, then click the **Confirm** button in the subsequent dialog to approve the update.
+           - If the **New Version Detected** notification does not appear, no upgrade is available.
+           </Tab>
+         </Tabs>
+         For more detailed instructions on upgrading the plugin, refer to the <ExternalSiteLink name="acp" href="extend/operator.html" children="Operator" /> documentation.
+4.  To upgrade the Redis instance itself, please refer to the [Instance Upgrade Guide](./how_to/30-upgrade.mdx).

--- a/docs/en/upgrade.mdx
+++ b/docs/en/upgrade.mdx
@@ -60,10 +60,10 @@ Alauda Cache Service for Redis OSS v4.1.x and v4.0.x have not been tested on ACP
 ### Major Version Upgrade
 
 *   **Requirement**: When upgrading across major versions (e.g., `4.1.0` → `5.0.0`), upgrade directly to the latest available release of the target major version.
-*   **Procedure**: Follow the [Upgrade Steps](#upgrade-steps) below to upgrade the operator, then upgrade individual instances per the [Instance Upgrade Guide](./how_to/30-upgrade.mdx).
+*   **Procedure**: Follow the upgrade steps below to upgrade the operator, then upgrade individual instances per the [Instance Upgrade Guide](./how_to/30-upgrade.mdx).
 *   **Considerations**: Major upgrades may necessitate configuration modifications and a comprehensive review of feature compatibility.
 
-## Upgrade Steps {#upgrade-steps}
+## Upgrade Steps
 
 1.  Download the target version of the `Alauda Cache Service for Redis OSS` plugin from AlaudaCloud to a node that has access to your ACP cluster.
 2.  Utilize the `violet` package management tool to upload the plugin to the target cluster. For detailed instructions, refer to the <ExternalSiteLink name="acp" href="extend/upload_package.html" children="Upload Packages" /> documentation.

--- a/docs/en/upgrade.mdx
+++ b/docs/en/upgrade.mdx
@@ -63,7 +63,7 @@ Alauda Cache Service for Redis OSS v4.1.x and v4.0.x have not been tested on ACP
 *   **Procedure**: Follow the [Upgrade Steps](#upgrade-steps) below to upgrade the operator, then upgrade individual instances per the [Instance Upgrade Guide](./how_to/30-upgrade.mdx).
 *   **Considerations**: Major upgrades may necessitate configuration modifications and a comprehensive review of feature compatibility.
 
-## Upgrade Steps
+## Upgrade Steps {#upgrade-steps}
 
 1.  Download the target version of the `Alauda Cache Service for Redis OSS` plugin from AlaudaCloud to a node that has access to your ACP cluster.
 2.  Utilize the `violet` package management tool to upload the plugin to the target cluster. For detailed instructions, refer to the <ExternalSiteLink name="acp" href="extend/upload_package.html" children="Upload Packages" /> documentation.

--- a/doom.config.yml
+++ b/doom.config.yml
@@ -21,3 +21,7 @@ releaseNotes:
       project = MiddleWare AND type = Bug AND ReleaseNotesStatus = Publish AND Feature in ("MiddleWare - Redis") AND fixVersion = Redis-v4.1.0
     mw-redis-v4.1-known: |
       project = MiddleWare AND type = Bug AND ReleaseNotesStatus = Publish AND Feature = "MiddleWare - Redis" AND affectedVersion in (Redis-v4.1.0) AND fixVersion is EMPTY
+    mw-redis-v5.0-fixed: |
+      project = MiddleWare AND type = Bug AND ReleaseNotesStatus = Publish AND Feature in ("MiddleWare - Redis") AND fixVersion = Redis-v5.0.0
+    mw-redis-v5.0-known: |
+      project = MiddleWare AND type = Bug AND ReleaseNotesStatus = Publish AND Feature = "MiddleWare - Redis" AND affectedVersion in (Redis-v5.0.0) AND fixVersion is EMPTY


### PR DESCRIPTION
- Add v5.0.0 release notes with Redis 8.4 support and expanded module APIs
- Update upgrade matrix for v5.0.0 (Redis 6.0.21/7.2.12/8.4.2, ACP v4.1/v4.2/v4.3)
- Add ACP v4.3 compatibility note recommending v5.0.0 upgrade first
- Restructure lifecycle policy into Full Support and Maintenance phases
- Add v5.0.0 query templates to doom.config.yml