### PR TITLE
docs(redis): release notes v4.1.4

### DIFF
--- a/docs/en/release_notes.mdx
+++ b/docs/en/release_notes.mdx
@@ -10,11 +10,18 @@ The following table shows the compatibility and support matrix between the Alaud
 
 | Alauda Cache Service for Redis OSS Version | Redis Versions         | ACP Version |
 |:-------------------------------------------|------------------------|:------------|
+| v4.1.4                                     | 5.0.15, 6.0.21, 7.2.14 | v4.1, v4.2  |
 | v4.1.3                                     | 5.0.15, 6.0.21, 7.2.12 | v4.1, v4.2  |
 | v4.1.2                                     | 5.0.15, 6.0.21, 7.2.12 | v4.1, v4.2  |
 | v4.1.1                                     | 5.0.15, 6.0.21, 7.2.12 | v4.1        |
 | v4.1.0                                     | 5.0.14, 6.0.20, 7.2.10 | v4.1        |
 | v4.0.x                                     | 5.0.14, 6.0.20, 7.2.x  | v4.0        |
+
+## v4.1.4
+
+### Fixed Issues
+
+{/* release-notes-for-bugs?template=mw-redis-v4.1.4-fixed&project=Middleware */}
 
 ## v4.1.3
 

--- a/doom.config.yml
+++ b/doom.config.yml
@@ -29,5 +29,3 @@ releaseNotes:
       status in (Done, Resolved) AND (labels not in (安全问题) OR labels is EMPTY) AND project = MIDDLEWARE AND Feature = "MiddleWare - Redis" AND fixVersion = Redis-v4.1.3 AND ReleaseNotesStatus = Publish
     mw-redis-v4.1.4-fixed: |
       status in (Done, Resolved) AND (labels not in (安全问题) OR labels is EMPTY) AND project = MIDDLEWARE AND Feature = "MiddleWare - Redis" AND fixVersion = Redis-v4.1.4 AND ReleaseNotesStatus = Publish
-    mw-redis-v4.1.4-known: |
-      project = MiddleWare AND type = Bug AND ReleaseNotesStatus = Publish AND Feature = "MiddleWare - Redis" AND affectedVersion in (Redis-v4.1.4) AND fixVersion is EMPTY

--- a/doom.config.yml
+++ b/doom.config.yml
@@ -27,3 +27,7 @@ releaseNotes:
       status in (Done, Resolved) AND (labels not in (安全问题) OR labels is EMPTY) AND project = MIDDLEWARE AND Feature = "MiddleWare - Redis" AND fixVersion = Redis-v4.1.2 AND ReleaseNotesStatus = Publish
     mw-redis-v4.1.3-fixed: |
       status in (Done, Resolved) AND (labels not in (安全问题) OR labels is EMPTY) AND project = MIDDLEWARE AND Feature = "MiddleWare - Redis" AND fixVersion = Redis-v4.1.3 AND ReleaseNotesStatus = Publish
+    mw-redis-v4.1.4-fixed: |
+      status in (Done, Resolved) AND (labels not in (安全问题) OR labels is EMPTY) AND project = MIDDLEWARE AND Feature = "MiddleWare - Redis" AND fixVersion = Redis-v4.1.4 AND ReleaseNotesStatus = Publish
+    mw-redis-v4.1.4-known: |
+      project = MiddleWare AND type = Bug AND ReleaseNotesStatus = Publish AND Feature = "MiddleWare - Redis" AND affectedVersion in (Redis-v4.1.4) AND fixVersion is EMPTY


### PR DESCRIPTION
docs(redis): release notes v4.1.4

Updates `doom.config.yml` `releaseNotes.queryTemplates` so the published Jira release notes render on the docs site.

- base: `release-4.1`
- branch: `update-release-note-v4.1.4-release-4.1`
- Jira: MIDDLEWARE-31529 (ReleaseNotesStatus=Publish)

Generated by app-service-doc-release-notes (step 2 of app-service-publish-loop).