### PR TITLE
fix: bump release notes v4.1.5 to v4.1.6

### DIFF
--- a/docs/en/release_notes.mdx
+++ b/docs/en/release_notes.mdx
@@ -10,14 +10,14 @@ The following table shows the compatibility and support matrix between the Alaud
 
 | Alauda Cache Service for Redis OSS Version | Redis Versions         | ACP Version |
 |:-------------------------------------------|------------------------|:------------|
-| v4.1.5                                     | 5.0.15, 6.0.21, 7.2.14 | v4.1, v4.2  |
+| v4.1.6                                     | 5.0.15, 6.0.21, 7.2.14 | v4.1, v4.2  |
 | v4.1.3                                     | 5.0.15, 6.0.21, 7.2.12 | v4.1, v4.2  |
 | v4.1.2                                     | 5.0.15, 6.0.21, 7.2.12 | v4.1, v4.2  |
 | v4.1.1                                     | 5.0.15, 6.0.21, 7.2.12 | v4.1        |
 | v4.1.0                                     | 5.0.14, 6.0.20, 7.2.10 | v4.1        |
 | v4.0.x                                     | 5.0.14, 6.0.20, 7.2.x  | v4.0        |
 
-## v4.1.5
+## v4.1.6
 
 ### Fixed Issues
 


### PR DESCRIPTION
## Summary
- v4.1.5 had bugs, so republish the release as **v4.1.6**.
- Bump the compatibility & support matrix row `v4.1.5` → `v4.1.6`.
- Bump the release-notes section heading `v4.1.5` → `v4.1.6`.

The `Fixed Issues` placeholder is intentionally left at `mw-redis-v4.1.4-fixed` (unchanged from the prior version reset).

## Test plan
- Docs-only change; confirmed no remaining `4.1.5` references in the docs tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)