### PR TITLE
docs(redis): add v5.0.1 compatibility matrix row

### DIFF
--- a/docs/en/release_notes.mdx
+++ b/docs/en/release_notes.mdx
@@ -14,6 +14,7 @@ The following table shows the compatibility and support matrix between the Alaud
 
 | Alauda Cache Service for Redis OSS Version | Redis Versions         | ACP Version      |
 |:-------------------------------------------|------------------------|:-----------------|
+| v5.0.1                                     | 6.0.21, 7.2.14, 8.4.3  | v4.1, v4.2, v4.3 |
 | v5.0.0                                     | 6.0.21, 7.2.12, 8.4.2  | v4.1, v4.2, v4.3 |
 | v4.1.x                                     | 5.0.14, 6.0.20, 7.2.10 | v4.1, v4.2       |
 | v4.0.x                                     | 5.0.14, 6.0.20, 7.2.x  | v4.0             |


### PR DESCRIPTION
## Summary

Follow-up to #45 (merged) — adds the **v5.0.1 row** to the *Compatibility and support matrix*, which #45 merged just before this row was added:

`v5.0.1 | 6.0.21, 7.2.14, 8.4.3 | v4.1, v4.2, v4.3`

The security fix bumped Redis 7.2→7.2.14 and 8.4→8.4.3; 6.0 was unaffected (stays 6.0.21). The `## v5.0.1` section + queryTemplates already landed via #45.

`doom lint`: 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
