### PR TITLE
docs(redis): release notes for v5.0.2 (security patch)

### DIFF
--- a/docs/en/release_notes.mdx
+++ b/docs/en/release_notes.mdx
@@ -14,10 +14,27 @@ The following table shows the compatibility and support matrix between the Alaud
 
 | Alauda Cache Service for Redis OSS Version | Redis Versions         | ACP Version      |
 |:-------------------------------------------|------------------------|:-----------------|
+| v5.0.2                                     | 6.0.22, 7.2.15, 8.4.5  | v4.1, v4.2, v4.3 |
 | v5.0.1                                     | 6.0.21, 7.2.14, 8.4.3  | v4.1, v4.2, v4.3 |
 | v5.0.0                                     | 6.0.21, 7.2.12, 8.4.2  | v4.1, v4.2, v4.3 |
 | v4.1.x                                     | 5.0.14, 6.0.20, 7.2.10 | v4.1, v4.2       |
 | v4.0.x                                     | 5.0.14, 6.0.20, 7.2.x  | v4.0             |
+
+## v5.0.2
+
+This patch release contains security fixes only; it introduces no new features. It upgrades the bundled Redis Server builds to 6.0.22, 7.2.15, and 8.4.5.
+
+### Fixed Issues
+
+{/* release-notes-for-bugs?template=mw-redis-v5.0.2-fixed&project=Middleware */}
+
+### Known Issues
+
+{/* release-notes-for-bugs?template=mw-redis-v5.0.2-known&project=Middleware */}
+
+### Security Fixes
+
+{/* release-notes-for-bugs?template=mw-redis-v5.0.2-security&project=Middleware */}
 
 ## v5.0.1
 

--- a/docs/en/upgrade.mdx
+++ b/docs/en/upgrade.mdx
@@ -37,6 +37,7 @@ The following matrix outlines the tested version combinations and their respecti
 
 | Alauda Cache Service for Redis OSS Version | Redis Server Versions      | ACP Version      |
 |:-------------------------------------------|:---------------------------|:-----------------|
+| v5.0.2                                     | 6.0.22, 7.2.15, 8.4.5      | v4.1, v4.2, v4.3 |
 | v5.0.1                                     | 6.0.21, 7.2.14, 8.4.3      | v4.1, v4.2, v4.3 |
 | v5.0.0                                     | 6.0.21, 7.2.12, 8.4.2      | v4.1, v4.2, v4.3 |
 | v4.1.x                                     | 5.0.14, 6.0.20, 7.2.10     | v4.1, v4.2       |

--- a/doom.config.yml
+++ b/doom.config.yml
@@ -31,3 +31,9 @@ releaseNotes:
       project = MiddleWare AND type = Bug AND ReleaseNotesStatus = Publish AND Feature = "MiddleWare - Redis" AND affectedVersion in (Redis-v5.0.1) AND fixVersion is EMPTY
     mw-redis-v5.0.1-security: |
       project = MIDDLEWARE AND (issuetype = Vulnerability OR labels in (安全问题)) AND fixVersion = Redis-v5.0.1 AND ReleaseNotesStatus = Publish
+    mw-redis-v5.0.2-fixed: |
+      status in (Done, Resolved) AND (labels not in (安全问题) OR labels is EMPTY) AND project = MIDDLEWARE AND Feature = "MiddleWare - Redis" AND fixVersion = Redis-v5.0.2 AND ReleaseNotesStatus = Publish
+    mw-redis-v5.0.2-known: |
+      project = MiddleWare AND type = Bug AND ReleaseNotesStatus = Publish AND Feature = "MiddleWare - Redis" AND affectedVersion in (Redis-v5.0.2) AND fixVersion is EMPTY
+    mw-redis-v5.0.2-security: |
+      project in (MIDDLEWARE, ECO) AND (issuetype = Vulnerability OR labels in (安全问题)) AND fixVersion = Redis-v5.0.2 AND ReleaseNotesStatus = Publish


### PR DESCRIPTION
Release notes for Alauda Cache Service for Redis OSS **v5.0.2** (CVE/security patch on the 5.0 line).

- Compatibility matrix rows (release_notes + upgrade): v5.0.2 | Redis 6.0.22, 7.2.15, 8.4.5 | ACP v4.1, v4.2, v4.3
- `## v5.0.2` section with Fixed/Known/Security directives
- doom.config queryTemplates for v5.0.2, including an ECO-aware security template (the v5.0.2 vulnerability tickets live in the ECO project post-migration)

Verification: CVE scan 45 fixed / 0 regressions; dual-arch full-suite green on ACP 4.3; multi-ACP runs on 4.2/4.1 clean for everything those platforms support. `doom lint`: 0 errors / 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)